### PR TITLE
feat: support only setup function

### DIFF
--- a/src/core/createTransform.ts
+++ b/src/core/createTransform.ts
@@ -50,7 +50,7 @@ export const createTransform = (vueVersion?: string, filters?: FilteringRules) =
                       hasNameProperty = true;
                     }
                   }
-                } else if((isFunctionExpression(arg) || isArrowFunctionExpression(arg))) {               
+                } else if(isFunctionExpression(arg) || isArrowFunctionExpression(arg)) {               
                     const defineOptionsCode = s.slice(callExpr.start! + loc.start.offset, callExpr.end! + loc.start.offset)
                     const startPos = defineOptionsCode.indexOf('(') + 1;
                     s.appendLeft(callExpr.start! + loc.start.offset + startPos, `{name:'${componentName}',setup:`);
@@ -83,7 +83,7 @@ export const createTransform = (vueVersion?: string, filters?: FilteringRules) =
                   hasNameProperty = true;
                 }
               }
-              if (!hasNameProperty) {  
+              if (!hasNameProperty) {
                 const defineOptionsCode = s.slice(callExpr.start! + loc.start.offset, callExpr.end! + loc.start.offset)
                 const startPos = defineOptionsCode.indexOf('{') + 1;
                 s.appendLeft(callExpr.start! + loc.start.offset + startPos, `name:'${componentName}',`);

--- a/test/components/SetupFunction/index.vue
+++ b/test/components/SetupFunction/index.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <h1>{{msg}}</h1>
+  </div>
+</template>
+
+<script lang="ts">
+import {defineComponent} from "vue"
+export default defineComponent(()=>{
+      return {
+        msg: 'Component SetupFunction'
+      }
+})
+</script>

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -3,6 +3,7 @@ import ComponentA from "./components/ComponentA/index.vue?raw"
 import ComponentB from "./components/ComponentB/index.vue?raw"
 import TestSetupName from "./components/index.vue?raw"
 import ExportDefaultExists from "./components/ExportDefault/index.vue?raw"
+import SetupFunction from "./components/SetupFunction/index.vue?raw"
 import { createTransform } from "../src/core/createTransform"
 import { GenComponentName } from '../src/types'
 
@@ -126,6 +127,30 @@ describe('The behavior of transform in Vue 3.3.0 and below.', () => {
       const b = ('component B')
       </script>
       "
+    `)
+  })
+  it('when only setup function', () => {
+    const code = transform(SetupFunction, 'components/SetupFunction/index.vue')?.code
+   console.log(code)
+    expect(code).toContain(`name:'SetupFunction'`)
+    expect(code).toContain(`setup:()=>{`)
+    expect(code).toContain(`msg: 'Component SetupFunction'`)
+    expect(code).toMatchInlineSnapshot(`
+    "<template>
+      <div>
+        <h1>{{msg}}</h1>
+      </div>
+    </template>
+    
+    <script lang="ts">
+    import {defineComponent} from "vue"
+    export default defineComponent({name:'SetupFunction',setup:()=>{
+          return {
+            msg: 'Component SetupFunction'
+          }
+    }})
+    </script>
+    "
     `)
   })
 })


### PR DESCRIPTION
这个PR增加了对只有setup函数参数的defineComponent的支持

示例:
```vue
<template>
  <div>
     <h1>{{msg}}</h1>
  </div>
</template>
    
<script lang="ts">
  import {defineComponent} from "vue"
  export default defineComponent(()=>{
      return {
            msg: 'Component SetupFunction'
      }
  })
</script>
```